### PR TITLE
Fix commit message and push command typo

### DIFF
--- a/sync-repo.sh
+++ b/sync-repo.sh
@@ -3,11 +3,11 @@
 
 git add .
 
-git commit -m "Updated"
+git commit -m "Bumped version"
 
 git pull origin main
 
-git push 
+git push orign main
 
 # Check if the push was successful
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
This pull request makes minor updates to the `sync-repo.sh` script, including updating the commit message and fixing a typo in the `git push` command.